### PR TITLE
Parameter tweaks

### DIFF
--- a/waveorder_bf_to_phase.py
+++ b/waveorder_bf_to_phase.py
@@ -25,6 +25,7 @@ PARAMS = {
     "wavelength_illumination": 0.525,
     "numerical_aperture_illumination": 0.52,
     "numerical_aperture_detection": 1.4,
+    "invert_phase_contrast": True,
 }
 
 

--- a/waveorder_bf_to_phase.py
+++ b/waveorder_bf_to_phase.py
@@ -21,7 +21,7 @@ PARAMS = {
     "yx_pixel_size": 6.5 / 60,
     "z_pixel_size": 0.5,
     "index_of_refraction_media": 1.520,
-    "z_padding": 0,
+    "z_padding": 20,
     "wavelength_illumination": 0.525,
     "numerical_aperture_illumination": 0.52,
     "numerical_aperture_detection": 1.4,


### PR DESCRIPTION
This looks closer to what I'd expect. 

- `invert_phase_contrast` solves a problem that doesn't affect fluorescence deconvolution --- there ambiguity about which way is up and which contrast inversion means brighter or darker. In the reconstruction I'm now seeing consistently brighter signals in the puncta and other structure (compared to contrast inversions in the raw data, and darker signals in your first pass). 
- `z_padding` removes some wrapping artifacts at the top and bottom of the reconstruction. Reconstruction is now much thinner as we'd expect. 

<img width="1314" height="646" alt="Screenshot 2025-09-09 at 6 32 25 PM" src="https://github.com/user-attachments/assets/413d58ed-bfcb-4bb9-9c36-ac465f559e34" />
